### PR TITLE
Put the right fts db uri from environment

### DIFF
--- a/ingestors/settings.py
+++ b/ingestors/settings.py
@@ -47,7 +47,9 @@ NER_TYPE_MODEL_PATH = env.get(
 )
 
 # Use the environment variable set in aleph.env
-fts.DATABASE_URI = env.get("ALEPH_DATABASE_URI", fts.DATABASE_URI)
+fts.DATABASE_URI = env.get(
+    "FTM_STORE_URI", env.get("ALEPH_DATABASE_URI", fts.DATABASE_URI)
+)
 
 # Also store cached values in the SQL database
 sls.TAGS_DATABASE_URI = fts.DATABASE_URI


### PR DESCRIPTION
i don't know the intention of this variable assignement and cannot oversee all side-effects about changing it as proposed, but for now with assigning `ALEPH_DATABASE_URI` to ftm store in ingest file, when using different databases for aleph (`ALEPH_DATABASE_URI` and ftm store `FTM_STORE_URI`, this creates a **complete mess** (inserting entities derived from the ingestors into the aleph db, but other entities into ftm store db)

this small fix solves this issue