### PR TITLE
Emit a partial table with essential metadata before processing rows. Fixes #171

### DIFF
--- a/ingestors/manager.py
+++ b/ingestors/manager.py
@@ -147,7 +147,7 @@ class Manager(object):
             entity.set("processingStatus", self.STATUS_SUCCESS)
         except ProcessingException as pexc:
             entity.set("processingError", stringify(pexc))
-            log.error("[%r] Failed to process: %s", entity, pexc)
+            log.exception("[%r] Failed to process: %s", entity, pexc)
         finally:
             self.finalize(entity)
 

--- a/ingestors/tabular/access.py
+++ b/ingestors/tabular/access.py
@@ -59,6 +59,10 @@ class AccessIngestor(Ingestor, TableSupport, ShellSupport):
             table = self.manager.make_entity("Table", parent=entity)
             table.make_id(entity.id, table_name)
             table.set("title", table_name)
+            # Emit a partial table fragment with parent reference and name
+            # early, so that we don't have orphan fragments in case of an error
+            # in the middle of processing.
+            self.manager.emit_entity(table, fragment="initial")
             rows = self.generate_rows(file_path, table_name)
             self.emit_row_dicts(table, rows)
             self.manager.emit_entity(table)

--- a/ingestors/tabular/ods.py
+++ b/ingestors/tabular/ods.py
@@ -63,6 +63,10 @@ class OpenOfficeSpreadsheetIngestor(Ingestor, TableSupport, OpenDocumentSupport)
             table = self.manager.make_entity("Table", parent=entity)
             table.make_id(entity.id, name)
             table.set("title", name)
+            # Emit a partial table fragment with parent reference and name
+            # early, so that we don't have orphan fragments in case of an error
+            # in the middle of processing.
+            self.manager.emit_entity(table, fragment="initial")
             self.emit_row_tuples(table, self.generate_csv(sheet))
             if table.has("csvHash"):
                 self.manager.emit_entity(table)

--- a/ingestors/tabular/sqlite.py
+++ b/ingestors/tabular/sqlite.py
@@ -57,6 +57,10 @@ class SQLiteIngestor(Ingestor, TableSupport):
                 table = self.manager.make_entity("Table", parent=entity)
                 table.make_id(entity, table_name)
                 table.set("title", table_name)
+                # Emit a partial table fragment with parent reference and name
+                # early, so that we don't have orphan fragments in case of an error
+                # in the middle of processing.
+                self.manager.emit_entity(table, fragment="initial")
                 rows = self.generate_rows(conn, table_name)
                 self.emit_row_dicts(table, rows)
                 self.manager.emit_entity(table)

--- a/ingestors/tabular/xls.py
+++ b/ingestors/tabular/xls.py
@@ -57,6 +57,10 @@ class ExcelIngestor(Ingestor, TableSupport, OLESupport):
                 table = self.manager.make_entity("Table", parent=entity)
                 table.make_id(entity.id, sheet.name)
                 table.set("title", sheet.name)
+                # Emit a partial table fragment with parent reference and name
+                # early, so that we don't have orphan fragments in case of an error
+                # in the middle of processing.
+                self.manager.emit_entity(table, fragment="initial")
                 self.emit_row_tuples(table, self.generate_csv(sheet))
                 if table.has("csvHash"):
                     self.manager.emit_entity(table)

--- a/ingestors/tabular/xlsx.py
+++ b/ingestors/tabular/xlsx.py
@@ -47,6 +47,10 @@ class ExcelXMLIngestor(Ingestor, TableSupport, OOXMLSupport):
                 table = self.manager.make_entity("Table", parent=entity)
                 table.make_id(entity.id, name)
                 table.set("title", name)
+                # Emit a partial table fragment with parent reference and name
+                # early, so that we don't have orphan fragments in case of an error
+                # in the middle of processing.
+                self.manager.emit_entity(table, fragment="initial")
                 log.debug("Sheet: %s", name)
                 self.emit_row_tuples(table, self.generate_rows(sheet))
                 if table.has("csvHash"):


### PR DESCRIPTION
The partial initial fragment contains essential properties like name,
parent etc so that any row fragments produced from the table don't end
up orphaned even if there is a error during processing.