### PR TITLE
Fix missing link between attachments and emails in PST files

### DIFF
--- a/ingestors/email/outlookpst.py
+++ b/ingestors/email/outlookpst.py
@@ -24,12 +24,9 @@ class OutlookPSTIngestor(Ingestor, TempFileSupport, OLESupport, ShellSupport):
             self.exec_command(
                 "readpst",
                 "-e",  # make subfolders, files per message
-                "-S",  # single files
                 "-D",  # include deleted
-                # '-r',   # recursive structure
                 "-8",  # utf-8 where possible
                 "-cv",  # export vcards
-                # '-q',   # quiet
                 "-o",
                 temp_dir,
                 file_path,


### PR DESCRIPTION
The `-S` option to `readpst` extracts attachments out as separate files. We don't want to enable that option because we want the RFC822Ingestor to take care of extracting attachments and linking them to the corresponding Email entity.

Fixes #196