### PR TITLE
Fix build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -116,7 +116,8 @@ RUN groupadd -g 1000 -r app \
 RUN mkdir /models/ && \
     curl -o "/models/model_type_prediction.ftz" "https://public.data.occrp.org/develop/models/types/type-08012020-7a69d1b.ftz"
 
-RUN pip3 install --no-cache-dir -U pip setuptools
+# Having updated pip/setuptools seems to break the test run for some reason (12/01/2022)
+# RUN pip3 install --no-cache-dir -U pip setuptools
 COPY requirements.txt /tmp/
 RUN pip3 install --no-cache-dir -r /tmp/requirements.txt
 


### PR DESCRIPTION
With a little help from @pudo. Something about the latest iteration of pip -e seems to break our builds here (opensanctions has a similar issue). Removing the pip install -U command works around the issue for the time being.