### PR TITLE
[fix] cloud vision API types import error

### DIFF
--- a/ingestors/support/ocr.py
+++ b/ingestors/support/ocr.py
@@ -133,7 +133,10 @@ class GoogleOCRService(object):
         log.info("Using Google Vision API. Charges apply.")
 
     def extract_text(self, data, languages=None):
-        from google.cloud.vision import types
+        try:
+            from google.cloud.vision import types
+        except ImportError:
+            from google.cloud.vision_v1 import types
 
         image = types.Image(content=data)
         res = self.client.document_text_detection(image)


### PR DESCRIPTION
During Google Cloud Vision API usage, there is an import error (see below) due to the API [breaking changes](https://googleapis.dev/python/vision/latest/UPGRADING.html#enums-and-types) after upgrade (currently ingest-file is using vision api v.2.6.3).

Based on the API changelog, either updated version should be used, or previous version import should be implemented:
from this: `from google.cloud.vision import types`
to this: `from google.cloud.vision_v1 import types`
in: [`ingestors/support/ocr.py`](https://github.com/alephdata/ingest-file/blob/main/ingestors/support/ocr.py#L136)

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/servicelayer/worker.py", line 31, in handle_safe
    self.handle(task)
  File "/ingestors/ingestors/worker.py", line 48, in handle
    entity_ids = self._ingest(dataset, task)
  File "/ingestors/ingestors/worker.py", line 24, in _ingest
    manager.ingest_entity(entity)
  File "/ingestors/ingestors/manager.py", line 128, in ingest_entity
    self.ingest(file_path, entity)
  File "/ingestors/ingestors/manager.py", line 142, in ingest
    self.delegate(ingestor_class, file_path, entity)
  File "/ingestors/ingestors/manager.py", line 156, in delegate
    ingestor_class(self).ingest(file_path, entity)
  File "/ingestors/ingestors/documents/pdf.py", line 54, in ingest
    self.pdf_extract(entity, pdf)
  File "/ingestors/ingestors/support/pdf.py", line 18, in pdf_extract
    self.pdf_extract_page(entity, temp_dir, page)
  File "/ingestors/ingestors/support/pdf.py", line 35, in pdf_extract_page
    text = self.extract_ocr_text(data, languages=languages)
  File "/ingestors/ingestors/support/ocr.py", line 41, in extract_ocr_text
    text = settings._ocr_service.extract_text(data, languages=languages)
  File "/ingestors/ingestors/support/ocr.py", line 136, in extract_text
    from google.cloud.vision import types
ImportError: cannot import name 'types' from 'google.cloud.vision' (/usr/local/lib/python3.8/dist-packages/google/cloud/vision/__init__.py)
```