### PR TITLE
Improve PDF create/modify timestamps extraction

### DIFF
--- a/ingestors/documents/pdf.py
+++ b/ingestors/documents/pdf.py
@@ -42,6 +42,10 @@ class PDFIngestor(Ingestor, PDFSupport):
             entity.add("generator", meta.get("creator"))
             entity.add("generator", meta.get("producer"))
             entity.add("keywords", meta.get("subject"))
+            if "creationdate" in meta:
+                entity.add("authoredAt", meta.get("creationdate"))
+            if "moddate" in meta:
+                entity.add("modifiedAt", meta.get("moddate"))
 
     def ingest(self, file_path, entity):
         """Ingestor implementation."""


### PR DESCRIPTION
There are two formats of PDF metadata:

- the old one (a key-value dict)
- XMP (introduced by Adobe in early 00's)

These days, XMP must always be used instead of the old format. Theoretically :) In fact, both formats are used into the wild.

`pdf.py` extracts PDF metadata as follows:

- it tries to read the old format metadata, but, for unknown reason, _does not try to read create/modify timestamps_
- then it tries to read XMP metadata, and, this time, it reads create/modify timestamps

As result, if XMP metadata is not in the PDF file or the metadata does not have create/modify timestamps, the timestamps are absent. This happens even if the timestamps can be read from the old format metadata.

The pull request adds reading create/modify timestamps from the old format metadata.