### PR TITLE
Add JSON logging support (if ALEPH_JSON_LOGGING is truthy)

### DIFF
--- a/convert/convert/app.py
+++ b/convert/convert/app.py
@@ -1,5 +1,5 @@
 import os
-import logging
+from ingestors.log import get_logger
 from flask import Flask, request, send_file
 from pantomime import FileName, normalize_mimetype, mimetype_extension
 from pantomime.types import PDF
@@ -11,7 +11,7 @@ from convert.util import CONVERT_DIR, MAX_TIMEOUT
 from convert.util import SystemFailure, ConversionFailure
 
 logging.basicConfig(level=logging.DEBUG)
-log = logging.getLogger("convert")
+log = get_logger("convert")
 app = Flask("convert")
 lock = FileLock()
 extensions = load_mime_extensions()

--- a/convert/convert/lock.py
+++ b/convert/convert/lock.py
@@ -1,9 +1,9 @@
 import os
-import logging
+from ingestors.log import get_logger
 from tempfile import gettempdir
 from psutil import pid_exists
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class FileLock:

--- a/convert/convert/process.py
+++ b/convert/convert/process.py
@@ -1,6 +1,6 @@
 import os
 import time
-import logging
+from ingestors.log import get_logger
 import subprocess
 from psutil import process_iter, TimeoutExpired, NoSuchProcess
 
@@ -8,7 +8,7 @@ from convert.util import CONVERT_DIR, flush_path, MAX_TIMEOUT
 from convert.util import ConversionFailure
 
 OUT_DIR = os.path.join(CONVERT_DIR, "out")
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class ProcessConverter:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,6 @@ services:
       - /data:mode=777
     environment:
       FTM_STORE_URI: postgresql://ingest:ingest@postgres/ingest
-      INGESTORS_CONVERT_DOCUMENT_URL: http://127.0.0.1:3000/convert
     volumes:
       - "./ingestors:/ingestors/ingestors"
       - "./tests:/ingestors/tests"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       - /data:mode=777
     environment:
       FTM_STORE_URI: postgresql://ingest:ingest@postgres/ingest
+      ALEPH_JSON_LOGGING: 1
     volumes:
       - "./ingestors:/ingestors/ingestors"
       - "./tests:/ingestors/tests"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       - /data:mode=777
     environment:
       FTM_STORE_URI: postgresql://ingest:ingest@postgres/ingest
+      INGESTORS_CONVERT_DOCUMENT_URL: http://127.0.0.1:3000/convert
     volumes:
       - "./ingestors:/ingestors/ingestors"
       - "./tests:/ingestors/tests"

--- a/ingestors/__init__.py
+++ b/ingestors/__init__.py
@@ -1,10 +1,11 @@
 """Provides a set of ingestors based on different file types."""
 import logging
+from ingestors.log import get_logger
 
 __version__ = "3.17.1"
 
-logging.getLogger("chardet").setLevel(logging.INFO)
-logging.getLogger("PIL").setLevel(logging.INFO)
-logging.getLogger("google.auth").setLevel(logging.INFO)
-logging.getLogger("urllib3").setLevel(logging.WARNING)
-logging.getLogger("msglite").setLevel(logging.WARNING)
+get_logger("chardet").setLevel(logging.INFO)
+get_logger("PIL").setLevel(logging.INFO)
+get_logger("google.auth").setLevel(logging.INFO)
+get_logger("urllib3").setLevel(logging.WARNING)
+get_logger("msglite").setLevel(logging.WARNING)

--- a/ingestors/analysis/__init__.py
+++ b/ingestors/analysis/__init__.py
@@ -1,4 +1,4 @@
-import logging
+from ingestors.log import get_logger
 from itertools import chain
 from pprint import pprint  # noqa
 from followthemoney import model
@@ -15,7 +15,7 @@ from ingestors.analysis.language import detect_languages
 from ingestors.analysis.util import TAG_COMPANY, TAG_PERSON
 from ingestors.analysis.util import text_chunks, ANALYZABLE, DOCUMENT
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class Analyzer(object):

--- a/ingestors/analysis/aggregate.py
+++ b/ingestors/analysis/aggregate.py
@@ -1,10 +1,10 @@
-import logging
+from ingestors.log import get_logger
 from collections import defaultdict
 
 from ingestors.analysis.ft_type_model import FTTypeModel
 from ingestors.settings import NER_TYPE_MODEL_PATH
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class TagAggregatorFasttext(object):

--- a/ingestors/analysis/country.py
+++ b/ingestors/analysis/country.py
@@ -1,9 +1,9 @@
-import logging
+from ingestors.log import get_logger
 from banal import ensure_list
 from countrytagger import tag_place
 
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 def location_country(location):

--- a/ingestors/analysis/extract.py
+++ b/ingestors/analysis/extract.py
@@ -1,5 +1,5 @@
 import spacy
-import logging
+from ingestors.log import get_logger
 from functools import lru_cache
 from normality import collapse_spaces
 from languagecodes import list_to_alpha3
@@ -11,7 +11,7 @@ from ingestors.analysis.country import location_country
 from ingestors.analysis.util import TAG_PERSON, TAG_COMPANY
 from ingestors.analysis.util import TAG_LOCATION, TAG_COUNTRY
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 NAME_MAX_LENGTH = 100
 NAME_MIN_LENGTH = 4
 # https://spacy.io/api/annotation#named-entities

--- a/ingestors/analysis/ft_type_model.py
+++ b/ingestors/analysis/ft_type_model.py
@@ -1,4 +1,4 @@
-import logging
+from ingestors.log import get_logger
 
 import fasttext
 import numpy as np
@@ -6,7 +6,7 @@ from normality import normalize
 
 from ingestors.util import SingletonDecorator
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 @SingletonDecorator
 class FTTypeModel(object):

--- a/ingestors/analysis/language.py
+++ b/ingestors/analysis/language.py
@@ -1,9 +1,9 @@
-import logging
+from ingestors.log import get_logger
 import fasttext
 
 from ingestors import settings
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 THRESHOLD = 0.6
 
 

--- a/ingestors/cli.py
+++ b/ingestors/cli.py
@@ -1,6 +1,6 @@
 import sys
 import click
-import logging
+from ingestors.log import get_logger
 from pprint import pprint
 from ftmstore import get_dataset
 from servicelayer.cache import get_redis, get_fakeredis
@@ -15,7 +15,7 @@ from ingestors.directory import DirectoryIngestor
 from ingestors.analysis import Analyzer
 from ingestors.worker import IngestWorker, OP_ANALYZE, OP_INGEST
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 STAGES = [OP_ANALYZE, OP_INGEST]
 
 

--- a/ingestors/documents/pdf.py
+++ b/ingestors/documents/pdf.py
@@ -1,11 +1,11 @@
-import logging
+from ingestors.log import get_logger
 from pdflib import Document
 
 from ingestors.ingestor import Ingestor
 from ingestors.support.pdf import PDFSupport
 from ingestors.exc import ProcessingException
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class PDFIngestor(Ingestor, PDFSupport):

--- a/ingestors/email/calendar.py
+++ b/ingestors/email/calendar.py
@@ -1,4 +1,4 @@
-import logging
+from ingestors.log import get_logger
 import icalendar
 from vobject.base import ParseError
 from banal import ensure_list
@@ -10,7 +10,7 @@ from ingestors.support.encoding import EncodingSupport
 from ingestors.support.email import EmailIdentity
 from ingestors.exc import ProcessingException
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 def cal_date(value):

--- a/ingestors/email/emlx.py
+++ b/ingestors/email/emlx.py
@@ -1,5 +1,5 @@
 import email
-import logging
+from ingestors.log import get_logger
 from email.policy import default
 from email.errors import MessageError
 from followthemoney import model
@@ -7,7 +7,7 @@ from followthemoney import model
 from ingestors.email.msg import RFC822Ingestor
 from ingestors.exc import ProcessingException
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class AppleEmlxIngestor(RFC822Ingestor):

--- a/ingestors/email/mbox.py
+++ b/ingestors/email/mbox.py
@@ -1,4 +1,4 @@
-import logging
+from ingestors.log import get_logger
 import mailbox
 from email.policy import default
 from email.generator import BytesGenerator
@@ -8,7 +8,7 @@ from followthemoney import model
 from ingestors.email.msg import RFC822Ingestor
 from ingestors.support.temp import TempFileSupport
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class MboxFileIngestor(RFC822Ingestor, TempFileSupport):

--- a/ingestors/email/msg.py
+++ b/ingestors/email/msg.py
@@ -1,5 +1,5 @@
 import email
-import logging
+from ingestors.log import get_logger
 from email.policy import default
 from email.errors import MessageError
 from pantomime import normalize_mimetype
@@ -10,7 +10,7 @@ from ingestors.support.email import EmailSupport
 from ingestors.support.encoding import EncodingSupport
 from ingestors.exc import ProcessingException
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class RFC822Ingestor(Ingestor, EmailSupport, EncodingSupport):

--- a/ingestors/email/olm.py
+++ b/ingestors/email/olm.py
@@ -1,5 +1,5 @@
 import shutil
-import logging
+from ingestors.log import get_logger
 import zipfile
 import pathlib
 from pprint import pprint  # noqa
@@ -14,7 +14,7 @@ from ingestors.support.timestamp import TimestampSupport
 from ingestors.support.email import EmailSupport, EmailIdentity
 from ingestors.exc import ProcessingException
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 MIME = "application/xml+opfmessage"
 
 

--- a/ingestors/email/outlookmsg.py
+++ b/ingestors/email/outlookmsg.py
@@ -1,4 +1,4 @@
-import logging
+from ingestors.log import get_logger
 from msglite import Message
 from olefile import isOleFile
 from normality import stringify
@@ -11,7 +11,7 @@ from ingestors.support.temp import TempFileSupport
 from ingestors.support.ole import OLESupport
 from ingestors.exc import ProcessingException
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 RTF_MIME = "application/rtf"
 
 

--- a/ingestors/email/outlookpst.py
+++ b/ingestors/email/outlookpst.py
@@ -1,4 +1,4 @@
-import logging
+from ingestors.log import get_logger
 from followthemoney import model
 
 from ingestors.ingestor import Ingestor
@@ -7,7 +7,7 @@ from ingestors.support.shell import ShellSupport
 from ingestors.support.ole import OLESupport
 from ingestors.directory import DirectoryIngestor
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class OutlookPSTIngestor(Ingestor, TempFileSupport, OLESupport, ShellSupport):

--- a/ingestors/email/vcard.py
+++ b/ingestors/email/vcard.py
@@ -1,4 +1,4 @@
-import logging
+from ingestors.log import get_logger
 import vobject
 from vobject.base import ParseError
 from banal import ensure_list
@@ -9,7 +9,7 @@ from ingestors.ingestor import Ingestor
 from ingestors.support.encoding import EncodingSupport
 from ingestors.exc import ProcessingException
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class VCardIngestor(Ingestor, EncodingSupport):

--- a/ingestors/ignore.py
+++ b/ingestors/ignore.py
@@ -1,8 +1,8 @@
-import logging
+from ingestors.log import get_logger
 
 from ingestors.ingestor import Ingestor
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class IgnoreIngestor(Ingestor):

--- a/ingestors/ingestor.py
+++ b/ingestors/ingestor.py
@@ -1,7 +1,7 @@
-import logging
+from ingestors.log import get_logger
 from pantomime import normalize_mimetype, normalize_extension
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class Ingestor(object):

--- a/ingestors/log.py
+++ b/ingestors/log.py
@@ -1,0 +1,19 @@
+import logging
+import os
+
+
+json_logging = bool(os.getenv("ALEPH_JSON_LOGGING", False))
+if json_logging:
+    from pythonjsonlogger import jsonlogger
+
+
+def get_logger(name: str) -> logging.Logger:
+    logger = logging.getLogger(name)
+
+    if json_logging:
+        logHandler = logging.StreamHandler()
+        formatter = jsonlogger.JsonFormatter()
+        logHandler.setFormatter(formatter)
+        logger.addHandler(logHandler)
+
+    return logger

--- a/ingestors/manager.py
+++ b/ingestors/manager.py
@@ -1,5 +1,5 @@
 import magic
-import logging
+from ingestors.log import get_logger
 from pprint import pprint  # noqa
 from tempfile import mkdtemp
 from followthemoney import model
@@ -18,7 +18,7 @@ from ingestors.exc import ProcessingException
 from ingestors.util import filter_text, remove_directory
 from ingestors import settings
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class Manager(object):

--- a/ingestors/media/audio.py
+++ b/ingestors/media/audio.py
@@ -1,4 +1,4 @@
-import logging
+from ingestors.log import get_logger
 from followthemoney import model
 from pymediainfo import MediaInfo
 
@@ -6,7 +6,7 @@ from ingestors.ingestor import Ingestor
 from ingestors.support.timestamp import TimestampSupport
 from ingestors.exc import ProcessingException
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class AudioIngestor(Ingestor, TimestampSupport):

--- a/ingestors/media/image.py
+++ b/ingestors/media/image.py
@@ -1,4 +1,4 @@
-import logging
+from ingestors.log import get_logger
 from io import BytesIO
 from PIL import Image, ExifTags
 from followthemoney import model
@@ -8,7 +8,7 @@ from ingestors.support.ocr import OCRSupport
 from ingestors.support.timestamp import TimestampSupport
 from ingestors.exc import ProcessingException
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class ImageIngestor(Ingestor, OCRSupport, TimestampSupport):

--- a/ingestors/media/svg.py
+++ b/ingestors/media/svg.py
@@ -1,11 +1,11 @@
-import logging
+from ingestors.log import get_logger
 from followthemoney import model
 
 from ingestors.ingestor import Ingestor
 from ingestors.support.html import HTMLSupport
 from ingestors.support.encoding import EncodingSupport
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class SVGIngestor(Ingestor, EncodingSupport, HTMLSupport):

--- a/ingestors/media/tiff.py
+++ b/ingestors/media/tiff.py
@@ -1,4 +1,4 @@
-import logging
+from ingestors.log import get_logger
 from followthemoney import model
 
 from ingestors.ingestor import Ingestor
@@ -6,7 +6,7 @@ from ingestors.support.pdf import PDFSupport
 from ingestors.support.shell import ShellSupport
 from ingestors.support.temp import TempFileSupport
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class TIFFIngestor(Ingestor, PDFSupport, TempFileSupport, ShellSupport):

--- a/ingestors/media/video.py
+++ b/ingestors/media/video.py
@@ -1,4 +1,4 @@
-import logging
+from ingestors.log import get_logger
 from followthemoney import model
 from pymediainfo import MediaInfo
 
@@ -6,7 +6,7 @@ from ingestors.ingestor import Ingestor
 from ingestors.support.timestamp import TimestampSupport
 from ingestors.exc import ProcessingException
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class VideoIngestor(Ingestor, TimestampSupport):

--- a/ingestors/misc/ftm.py
+++ b/ingestors/misc/ftm.py
@@ -1,12 +1,12 @@
-import logging
 from followthemoney.proxy import EntityProxy
 from followthemoney.cli.util import read_entities, read_entity
 from followthemoney.util import MEGABYTE
 
 from ingestors.ingestor import Ingestor
 from ingestors.support.encoding import EncodingSupport
+from ingestors.log import get_logger
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class FtMIngestor(Ingestor, EncodingSupport):

--- a/ingestors/packages/rar.py
+++ b/ingestors/packages/rar.py
@@ -1,11 +1,11 @@
-import logging
+from ingestors.log import get_logger
 import rarfile
 
 from ingestors.ingestor import Ingestor
 from ingestors.support.package import PackageSupport
 from ingestors.exc import ProcessingException
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class RARIngestor(PackageSupport, Ingestor):

--- a/ingestors/packages/tar.py
+++ b/ingestors/packages/tar.py
@@ -1,11 +1,11 @@
-import logging
+from ingestors.log import get_logger
 import tarfile
 
 from ingestors.ingestor import Ingestor
 from ingestors.support.package import PackageSupport
 from ingestors.exc import ProcessingException
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class TarIngestor(PackageSupport, Ingestor):

--- a/ingestors/packages/zip.py
+++ b/ingestors/packages/zip.py
@@ -1,11 +1,11 @@
-import logging
+from ingestors.log import get_logger
 import zipfile
 
 from ingestors.ingestor import Ingestor
 from ingestors.support.package import PackageSupport
 from ingestors.exc import ProcessingException
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class ZipIngestor(PackageSupport, Ingestor):

--- a/ingestors/support/cache.py
+++ b/ingestors/support/cache.py
@@ -1,11 +1,11 @@
-import logging
+from ingestors.log import get_logger
 from banal import ensure_list
 
 from servicelayer.tags import Tags
 from servicelayer.cache import make_key
 from servicelayer.settings import REDIS_LONG
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class CacheSupport(object):

--- a/ingestors/support/convert.py
+++ b/ingestors/support/convert.py
@@ -1,5 +1,5 @@
 import math
-import logging
+from ingestors.log import get_logger
 import requests
 from requests import RequestException, HTTPError
 from servicelayer.util import backoff
@@ -11,7 +11,7 @@ from ingestors.support.temp import TempFileSupport
 from ingestors.util import explicit_resolve
 from ingestors.exc import ProcessingException
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class DocumentConvertSupport(CacheSupport, TempFileSupport):

--- a/ingestors/support/email.py
+++ b/ingestors/support/email.py
@@ -1,6 +1,6 @@
 import re
 import types
-import logging
+from ingestors.log import get_logger
 from banal import ensure_list
 from normality import stringify
 from ftmstore.utils import safe_fragment
@@ -12,7 +12,7 @@ from ingestors.support.html import HTMLSupport
 from ingestors.support.cache import CacheSupport
 from ingestors.support.temp import TempFileSupport
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class EmailIdentity(object):

--- a/ingestors/support/encoding.py
+++ b/ingestors/support/encoding.py
@@ -1,4 +1,4 @@
-import logging
+from ingestors.log import get_logger
 import chardet
 from normality import stringify, guess_encoding
 from normality.encoding import guess_file_encoding, normalize_result
@@ -6,7 +6,7 @@ from normality.encoding import normalize_encoding
 
 from ingestors.exc import ProcessingException
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class EncodingSupport(object):

--- a/ingestors/support/html.py
+++ b/ingestors/support/html.py
@@ -1,5 +1,5 @@
 import re
-import logging
+from ingestors.log import get_logger
 from lxml import html
 from lxml.etree import ParseError, ParserError
 from normality import collapse_spaces
@@ -7,7 +7,7 @@ from normality import collapse_spaces
 from ingestors.support.timestamp import TimestampSupport
 from ingestors.exc import ProcessingException
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class HTMLSupport(TimestampSupport):

--- a/ingestors/support/ocr.py
+++ b/ingestors/support/ocr.py
@@ -1,5 +1,5 @@
 import time
-import logging
+from ingestors.log import get_logger
 import threading
 from hashlib import sha1
 from normality import stringify
@@ -11,7 +11,7 @@ from ingestors import settings
 from ingestors.support.cache import CacheSupport
 from ingestors.util import temp_locale
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 TESSERACT_LOCALE = "C"
 
 

--- a/ingestors/support/ole.py
+++ b/ingestors/support/ole.py
@@ -1,11 +1,11 @@
-import logging
+from ingestors.log import get_logger
 from pprint import pprint  # noqa
 from olefile import isOleFile, OleFileIO
 
 from ingestors.support.timestamp import TimestampSupport
 from ingestors.support.encoding import EncodingSupport
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class OLESupport(TimestampSupport, EncodingSupport):

--- a/ingestors/support/ooxml.py
+++ b/ingestors/support/ooxml.py
@@ -1,4 +1,4 @@
-import logging
+from ingestors.log import get_logger
 import zipfile
 from zipfile import ZipFile, BadZipfile
 
@@ -7,7 +7,7 @@ from ingestors.support.timestamp import TimestampSupport
 
 # from ingestors.exc import ProcessingException
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class OOXMLSupport(TimestampSupport, XMLSupport):

--- a/ingestors/support/opendoc.py
+++ b/ingestors/support/opendoc.py
@@ -1,10 +1,10 @@
-import logging
+from ingestors.log import get_logger
 from odf.opendocument import load
 
 from ingestors.support.timestamp import TimestampSupport
 from ingestors.exc import ProcessingException
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class OpenDocumentSupport(TimestampSupport):

--- a/ingestors/support/package.py
+++ b/ingestors/support/package.py
@@ -1,12 +1,12 @@
 import shutil
-import logging
+from ingestors.log import get_logger
 from followthemoney import model
 
 from ingestors.support.temp import TempFileSupport
 from ingestors.support.encoding import EncodingSupport
 from ingestors.directory import DirectoryIngestor
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class PackageSupport(TempFileSupport, EncodingSupport):

--- a/ingestors/support/table.py
+++ b/ingestors/support/table.py
@@ -1,5 +1,5 @@
 import csv
-import logging
+from ingestors.log import get_logger
 from pantomime.types import CSV
 from collections import OrderedDict
 from followthemoney.types import registry
@@ -8,7 +8,7 @@ from followthemoney.util import sanitize_text
 from ingestors.support.temp import TempFileSupport
 from ingestors.support.encoding import EncodingSupport
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class TableSupport(EncodingSupport, TempFileSupport):

--- a/ingestors/support/timestamp.py
+++ b/ingestors/support/timestamp.py
@@ -1,9 +1,9 @@
-import logging
+from ingestors.log import get_logger
 from banal import ensure_list
 from normality import stringify
 from datetime import datetime, date
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class TimestampSupport(object):

--- a/ingestors/support/xml.py
+++ b/ingestors/support/xml.py
@@ -1,11 +1,11 @@
-import logging
+from ingestors.log import get_logger
 from lxml import etree
 from lxml.etree import XMLSyntaxError, ParseError, ParserError
 from pathlib import Path
 
 from ingestors.exc import ProcessingException
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class XMLSupport(object):

--- a/ingestors/tabular/access.py
+++ b/ingestors/tabular/access.py
@@ -1,7 +1,7 @@
 import os
 import io
 import csv
-import logging
+from ingestors.log import get_logger
 import subprocess
 from collections import OrderedDict
 from followthemoney import model
@@ -11,7 +11,7 @@ from ingestors.support.shell import ShellSupport
 from ingestors.support.table import TableSupport
 from ingestors.exc import ProcessingException
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class AccessIngestor(Ingestor, TableSupport, ShellSupport):

--- a/ingestors/tabular/csv.py
+++ b/ingestors/tabular/csv.py
@@ -1,13 +1,13 @@
 import io
 import csv
-import logging
+from ingestors.log import get_logger
 from followthemoney import model
 
 from ingestors.ingestor import Ingestor
 from ingestors.support.table import TableSupport
 from ingestors.exc import ProcessingException
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class CSVIngestor(Ingestor, TableSupport):

--- a/ingestors/tabular/dbf.py
+++ b/ingestors/tabular/dbf.py
@@ -1,4 +1,4 @@
-import logging
+from ingestors.log import get_logger
 from dbf import Table, DbfError
 from collections import OrderedDict
 from normality import stringify
@@ -8,7 +8,7 @@ from ingestors.ingestor import Ingestor
 from ingestors.exc import ProcessingException
 from ingestors.support.table import TableSupport
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class DBFIngestor(Ingestor, TableSupport):

--- a/ingestors/tabular/ods.py
+++ b/ingestors/tabular/ods.py
@@ -1,4 +1,4 @@
-import logging
+from ingestors.log import get_logger
 from odf.teletype import extractText
 from odf.table import TableRow, TableCell, Table
 from odf.text import P
@@ -9,7 +9,7 @@ from ingestors.ingestor import Ingestor
 from ingestors.support.table import TableSupport
 from ingestors.support.opendoc import OpenDocumentSupport
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class OpenOfficeSpreadsheetIngestor(Ingestor, TableSupport, OpenDocumentSupport):

--- a/ingestors/tabular/sqlite.py
+++ b/ingestors/tabular/sqlite.py
@@ -1,5 +1,5 @@
 import re
-import logging
+from ingestors.log import get_logger
 import sqlite3
 from followthemoney import model
 from collections import OrderedDict
@@ -8,7 +8,7 @@ from ingestors.ingestor import Ingestor
 from ingestors.support.table import TableSupport
 from ingestors.exc import ProcessingException
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class SQLiteIngestor(Ingestor, TableSupport):

--- a/ingestors/tabular/xls.py
+++ b/ingestors/tabular/xls.py
@@ -1,5 +1,5 @@
 import xlrd
-import logging
+from ingestors.log import get_logger
 from datetime import datetime, time
 from xlrd.biffh import XLRDError
 from followthemoney import model
@@ -9,7 +9,7 @@ from ingestors.support.table import TableSupport
 from ingestors.support.ole import OLESupport
 from ingestors.exc import ProcessingException
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class ExcelIngestor(Ingestor, TableSupport, OLESupport):

--- a/ingestors/tabular/xlsx.py
+++ b/ingestors/tabular/xlsx.py
@@ -1,4 +1,4 @@
-import logging
+from ingestors.log import get_logger
 from followthemoney import model
 from openpyxl import load_workbook
 from xml.etree.ElementTree import ParseError
@@ -8,7 +8,7 @@ from ingestors.support.table import TableSupport
 from ingestors.support.ooxml import OOXMLSupport
 from ingestors.exc import ProcessingException
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class ExcelXMLIngestor(Ingestor, TableSupport, OOXMLSupport):

--- a/ingestors/worker.py
+++ b/ingestors/worker.py
@@ -1,4 +1,4 @@
-import logging
+from ingestors.log import get_logger
 from followthemoney import model
 from ftmstore import get_dataset
 from servicelayer.worker import Worker
@@ -8,7 +8,7 @@ from ingestors import __version__
 from ingestors.manager import Manager
 from ingestors.analysis import Analyzer
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 OP_INGEST = "ingest"
 OP_ANALYZE = "analyze"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,3 +38,4 @@ icalendar==4.1.0
 
 cryptography==37.0.4
 requests[security]==2.28.1
+python-json-logger==2.0.4


### PR DESCRIPTION
This adds log output in JSON format if the `ALEPH_JSON_LOGGING` env var is truthy. Since most of the diff is a search-and-replace it might help to know that the main logic change happened in `ingestors/log.py`.