### PR TITLE
Allow rc releases, aligning with aleph

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,6 +3,20 @@ current_version = 3.17.1
 tag_name = {new_version}
 commit = True
 tag = True
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)([-](?P<release>(pre|rc))(?P<build>\d+))?
+serialize =
+	{major}.{minor}.{patch}-{release}{build}
+	{major}.{minor}.{patch}
+
+[bumpversion:part:release]
+optional_value = prod
+first_value = rc
+values =
+	rc
+	prod
+
+[bumpversion:part:build]
+first_value = 1
 
 [bumpversion:file:setup.py]
 


### PR DESCRIPTION
As a test, trying to do a minor release with

```bash
$ bumpversion --dry-run --no-commit --allow-dirty --verbose minor
```

yields:

```bash
...
Would commit to Git with message 'Bump version: 3.17.1 → 3.18.0-rc1'
Would tag '3.18.0-rc1' with message 'Bump version: 3.17.1 → 3.18.0-rc1' in Git and not signing
```