### PR TITLE
Update pip, setuptools and wheel before installing packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -148,7 +148,7 @@ RUN python3 -m spacy download el_core_news_sm \
 
 COPY . /ingestors
 WORKDIR /ingestors
-RUN pip3 install --no-cache-dir -e /ingestors
+RUN pip3 install --no-cache-dir --config-settings editable_mode=compat --use-pep517 -e /ingestors
 RUN chown -R app:app /ingestors
 
 ENV ARCHIVE_TYPE=file \

--- a/Dockerfile
+++ b/Dockerfile
@@ -124,6 +124,8 @@ RUN mkdir /models/ && \
 # Having updated pip/setuptools seems to break the test run for some reason (12/01/2022)
 # RUN pip3 install --no-cache-dir -U pip setuptools
 COPY requirements.txt /tmp/
+RUN pip3 install --upgrade pip
+RUN pip3 install --upgrade setuptools wheel
 RUN pip3 install --no-cache-dir -r /tmp/requirements.txt
 
 # Install spaCy models

--- a/Dockerfile
+++ b/Dockerfile
@@ -124,9 +124,9 @@ RUN mkdir /models/ && \
 # Having updated pip/setuptools seems to break the test run for some reason (12/01/2022)
 # RUN pip3 install --no-cache-dir -U pip setuptools
 COPY requirements.txt /tmp/
-RUN pip3 install --upgrade pip
-RUN pip3 install --upgrade setuptools wheel
-RUN pip3 install --no-cache-dir -r /tmp/requirements.txt
+RUN pip3 install --no-cache-dir --prefer-binary --upgrade pip
+RUN pip3 install --no-cache-dir --prefer-binary --upgrade setuptools wheel
+RUN pip3 install --no-cache-dir --prefer-binary -r /tmp/requirements.txt
 
 # Install spaCy models
 RUN python3 -m spacy download en_core_web_sm \

--- a/Dockerfile
+++ b/Dockerfile
@@ -154,7 +154,8 @@ RUN chown -R app:app /ingestors
 ENV ARCHIVE_TYPE=file \
     ARCHIVE_PATH=/data \
     FTM_STORE_URI=postgresql://aleph:aleph@postgres/aleph \
-    REDIS_URL=redis://redis:6379/0
+    REDIS_URL=redis://redis:6379/0 \
+    TESSDATA_PREFIX=/usr/share/tesseract-ocr/4.00/tessdata
 
 # USER app
 CMD ingestors process

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ languagecodes==1.1.1
 countrytagger==0.1.2
 pyicu==2.11
 google-cloud-vision==3.4.4
-tesserocr==2.6.1
+tesserocr==2.5.2
 spacy==3.6.1
 fingerprints==1.1.1
 fasttext==0.9.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ languagecodes==1.1.1
 countrytagger==0.1.2
 pyicu==2.11
 google-cloud-vision==3.4.4
-tesserocr==2.5.2
+tesserocr==2.6.1
 spacy==3.6.1
 fingerprints==1.1.1
 fasttext==0.9.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ languagecodes==1.1.1
 countrytagger==0.1.2
 pyicu==2.10.2
 google-cloud-vision==3.4.4
-tesserocr==2.6.1
+tesserocr==2.6.0
 spacy==3.5.1
 fingerprints==1.1.0
 fasttext==0.9.2


### PR DESCRIPTION
This should fix lots of installation issues and ideally will use wheels wherever possible, shortening the build times.

(if you've ever waited for `building wheel for grpc.io` you know what I mean by build times ...)