### PR TITLE
Lower click version to avoid mismatch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ fasttext==0.9.2
 # Development
 pytest==7.4.0
 pytest-cov==4.1.0
-click==8.1.7
+click==8.1.6
 
 # File format support
 dbf==0.99.3


### PR DESCRIPTION
After https://github.com/alephdata/ingest-file/pull/508 a version mismatch was produced. We have to revert click until https://github.com/alephdata/followthemoney/pull/1227 gets released.