### PR TITLE
Add Prometheus instrumentation for ingest-file workers

### DIFF
--- a/ingestors/manager.py
+++ b/ingestors/manager.py
@@ -162,8 +162,11 @@ class Manager(object):
         """Main execution step of an ingestor."""
         file_path = ensure_path(file_path)
         file_size = None
-        if file_path.is_file() and not entity.has("fileSize"):
+
+        if file_path.is_file():
             file_size = file_path.stat().st_size  # size in bytes
+
+        if file_size is not None and not entity.has("fileSize"):
             entity.add("fileSize", file_size)
 
         now = datetime.now()
@@ -187,7 +190,9 @@ class Manager(object):
 
             INGEST_SUCCEEDED.labels(ingestor_name).inc()
             INGEST_DURATION.labels(ingestor_name).observe(duration)
-            INGEST_INGESTED_BYTES.labels(ingestor_name).inc(file_size)
+
+            if file_size is not None:
+                INGEST_INGESTED_BYTES.labels(ingestor_name).inc(file_size)
 
             entity.set("processingStatus", self.STATUS_SUCCESS)
         except ProcessingException as pexc:

--- a/ingestors/manager.py
+++ b/ingestors/manager.py
@@ -214,12 +214,7 @@ class Manager(object):
             entity.set("processingStatus", self.STATUS_SUCCESS)
         except ProcessingException as pexc:
             log.exception(f"[{repr(entity)}] Failed to process: {pexc}")
-
-            if ingestor_name:
-                INGESTIONS_FAILED.labels(ingestor=ingestor_name).inc()
-            else:
-                INGESTIONS_FAILED.labels(ingestor=None).inc()
-
+            INGESTIONS_FAILED.labels(ingestor=ingestor_name).inc()
             entity.set("processingError", stringify(pexc))
             capture_exception(pexc)
         finally:

--- a/ingestors/manager.py
+++ b/ingestors/manager.py
@@ -199,7 +199,7 @@ class Manager(object):
         try:
             ingestor_class = self.auction(file_path, entity)
             ingestor_name = ingestor_class.__name__
-            log.info("Ingestor [%r]: %s", entity, ingestor_name)
+            log.info(f"Ingestor [{repr(entity)}]: {ingestor_name}")
 
             start_time = default_timer()
             self.delegate(ingestor_class, file_path, entity)
@@ -213,7 +213,7 @@ class Manager(object):
 
             entity.set("processingStatus", self.STATUS_SUCCESS)
         except ProcessingException as pexc:
-            log.exception("[%r] Failed to process: %s", entity, pexc)
+            log.exception(f"[{repr(entity)}] Failed to process: {pexc}")
 
             if ingestor_name:
                 INGESTIONS_FAILED.labels(ingestor=ingestor_name).inc()

--- a/ingestors/manager.py
+++ b/ingestors/manager.py
@@ -39,6 +39,23 @@ INGEST_DURATION = Histogram(
     "ingest_duration_seconds",
     "Ingest duration by ingestor",
     ["ingestor"],
+    # The bucket sizes are a rough guess right now, we might want to adjust
+    # them later based on observed durations
+    buckets=[
+        0.005
+        0.01,
+        0.025,
+        0.05,
+        0.1,
+        0.25,
+        0.5,
+        1,
+        5,
+        15,
+        60,
+        5 * 60,
+        15 * 60,
+    ],
 )
 INGEST_INGESTED_BYTES = Counter(
     "ingest_ingested_bytes_total",

--- a/ingestors/manager.py
+++ b/ingestors/manager.py
@@ -205,20 +205,20 @@ class Manager(object):
             self.delegate(ingestor_class, file_path, entity)
             duration = max(0, default_timer() - start_time)
 
-            INGESTIONS_SUCCEEDED.labels(ingestor_name).inc()
-            INGESTION_DURATION.labels(ingestor_name).observe(duration)
+            INGESTIONS_SUCCEEDED.labels(ingestor=ingestor_name).inc()
+            INGESTION_DURATION.labels(ingestor=ingestor_name).observe(duration)
 
             if file_size is not None:
-                INGESTED_BYTES.labels(ingestor_name).inc(file_size)
+                INGESTED_BYTES.labels(ingestor=ingestor_name).inc(file_size)
 
             entity.set("processingStatus", self.STATUS_SUCCESS)
         except ProcessingException as pexc:
             log.exception("[%r] Failed to process: %s", entity, pexc)
 
             if ingestor_name:
-                INGESTIONS_FAILED.labels(ingestor_name).inc()
+                INGESTIONS_FAILED.labels(ingestor=ingestor_name).inc()
             else:
-                INGESTIONS_FAILED.labels(None).inc()
+                INGESTIONS_FAILED.labels(ingestor=None).inc()
 
             entity.set("processingError", stringify(pexc))
             capture_exception(pexc)

--- a/ingestors/support/convert.py
+++ b/ingestors/support/convert.py
@@ -15,8 +15,8 @@ log = logging.getLogger(__name__)
 TIMEOUT = 3600  # seconds
 CONVERT_RETRIES = 5
 
-INGEST_PDF_CACHE_ACCESSED = Counter(
-    "ingest_pdf_cache_accessed",
+PDF_CACHE_ACCESSED = Counter(
+    "ingestfile_pdf_cache_accessed",
     "Number of times the PDF cache has been accessed, by cache status",
     ["status"],
 )
@@ -32,12 +32,12 @@ class DocumentConvertSupport(CacheSupport, TempFileSupport):
             file_name = entity_filename(entity, extension="pdf")
             path = self.manager.load(pdf_hash, file_name=file_name)
             if path is not None:
-                INGEST_PDF_CACHE_ACCESSED.labels("hit").inc()
+                PDF_CACHE_ACCESSED.labels("hit").inc()
                 log.info("Using PDF cache: %s", file_name)
                 entity.set("pdfHash", pdf_hash)
                 return path
 
-        INGEST_PDF_CACHE_ACCESSED.labels("miss").inc()
+        PDF_CACHE_ACCESSED.labels("miss").inc()
         pdf_file = self._document_to_pdf(unique_tmpdir, file_path, entity)
         if pdf_file is not None:
             content_hash = self.manager.store(pdf_file)

--- a/ingestors/support/convert.py
+++ b/ingestors/support/convert.py
@@ -32,12 +32,12 @@ class DocumentConvertSupport(CacheSupport, TempFileSupport):
             file_name = entity_filename(entity, extension="pdf")
             path = self.manager.load(pdf_hash, file_name=file_name)
             if path is not None:
-                PDF_CACHE_ACCESSED.labels("hit").inc()
+                PDF_CACHE_ACCESSED.labels(status="hit").inc()
                 log.info("Using PDF cache: %s", file_name)
                 entity.set("pdfHash", pdf_hash)
                 return path
 
-        PDF_CACHE_ACCESSED.labels("miss").inc()
+        PDF_CACHE_ACCESSED.labels(status="miss").inc()
         pdf_file = self._document_to_pdf(unique_tmpdir, file_path, entity)
         if pdf_file is not None:
             content_hash = self.manager.store(pdf_file)

--- a/ingestors/support/convert.py
+++ b/ingestors/support/convert.py
@@ -4,6 +4,7 @@ import pathlib
 import subprocess
 
 from followthemoney.helpers import entity_filename
+from prometheus_client import Counter
 
 from ingestors.support.cache import CacheSupport
 from ingestors.support.temp import TempFileSupport
@@ -13,6 +14,12 @@ log = logging.getLogger(__name__)
 
 TIMEOUT = 3600  # seconds
 CONVERT_RETRIES = 5
+
+INGEST_PDF_CACHE_ACCESSED = Counter(
+    "ingest_pdf_cache_accessed",
+    "Number of times the PDF cache has been accessed, by cache status",
+    ["status"],
+)
 
 
 class DocumentConvertSupport(CacheSupport, TempFileSupport):
@@ -25,10 +32,12 @@ class DocumentConvertSupport(CacheSupport, TempFileSupport):
             file_name = entity_filename(entity, extension="pdf")
             path = self.manager.load(pdf_hash, file_name=file_name)
             if path is not None:
+                INGEST_PDF_CACHE_ACCESSED.labels("hit").inc()
                 log.info("Using PDF cache: %s", file_name)
                 entity.set("pdfHash", pdf_hash)
                 return path
 
+        INGEST_PDF_CACHE_ACCESSED.labels("miss").inc()
         pdf_file = self._document_to_pdf(unique_tmpdir, file_path, entity)
         if pdf_file is not None:
             content_hash = self.manager.store(pdf_file)

--- a/ingestors/worker.py
+++ b/ingestors/worker.py
@@ -3,6 +3,7 @@ from followthemoney import model
 from ftmstore import get_dataset
 from servicelayer.worker import Worker
 from servicelayer.logs import apply_task_context
+from prometheus_client import Info
 
 from ingestors import __version__
 from ingestors.manager import Manager
@@ -11,6 +12,9 @@ from ingestors.analysis import Analyzer
 log = logging.getLogger(__name__)
 OP_INGEST = "ingest"
 OP_ANALYZE = "analyze"
+
+SYSTEM = Info("ingestfile_system", "ingest-file system information")
+SYSTEM.info({"ingestfile_version": __version__})
 
 
 class IngestWorker(Worker):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ normality==2.4.0
 pantomime==0.6.1
 followthemoney==3.5.2
 followthemoney-store[postgresql]==3.0.6
-servicelayer[google,amazon]==1.22.0
+servicelayer[google,amazon]==1.22.1
 languagecodes==1.1.1
 countrytagger==0.1.2
 pyicu==2.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ normality==2.4.0
 pantomime==0.6.1
 followthemoney==3.5.2
 followthemoney-store[postgresql]==3.0.6
-servicelayer[google,amazon]==1.21.2
+servicelayer[google,amazon]==1.22.0
 languagecodes==1.1.1
 countrytagger==0.1.2
 pyicu==2.11


### PR DESCRIPTION
This PR adds instrumentation for ingest-file workers:

* Upgrades servicelayer to include basic metrics implemented in https://github.com/alephdata/servicelayer/pull/111
* Adds metrics related to ingest performance by ingestor (duration of tasks, bytes ingested, number of failed/succeeded tasks)
* Adds metric related to PDF cache performance (hits/misses)

In order to test these changes with a local Aleph instance:

* Build the ingest-file image using `docker build -t ghcr.io/alephdata/ingest-file:metrics .`.

* In you Aleph `docker-compose.dev.yml`, set the `ingest-file` image tag to `metrics`.

* In you Aleph `docker-compose.dev.yml`, set the `PROMETHEUS_ENABLED=true` environment variable for the `ingest-file` service.

* Run `docker compose -f docker-compose.dev.yml up` to apply the changes.

* Run `docker compose exec ingest-file curl http://localhost:9090/metrics`.