### PR TITLE
Respect the timeout and retry settings for converting documents

### DIFF
--- a/ingestors/settings.py
+++ b/ingestors/settings.py
@@ -5,7 +5,6 @@ from ftmstore import settings as fts
 TESTING = False
 
 CONVERT_TIMEOUT = env.to_int("INGESTORS_CONVERT_TIMEOUT", 300)  # seconds
-CONVERT_RETRIES = env.to_int("INGESTORS_CONVERT_RETRIES", 3)
 
 # Enable (expensive!) Google Cloud API
 OCR_VISION_API = env.to_bool("INGESTORS_OCR_VISION_API", False)

--- a/ingestors/settings.py
+++ b/ingestors/settings.py
@@ -4,8 +4,8 @@ from ftmstore import settings as fts
 
 TESTING = False
 
-CONVERT_TIMEOUT = env.to_int("INGESTORS_CONVERT_TIMEOUT", 7200)  # 2 hrs
-CONVERT_RETRIES = env.to_int("INGESTORS_CONVERT_RETRIES", 256)
+CONVERT_TIMEOUT = env.to_int("INGESTORS_CONVERT_TIMEOUT", 300)  # seconds
+CONVERT_RETRIES = env.to_int("INGESTORS_CONVERT_RETRIES", 3)
 
 # Enable (expensive!) Google Cloud API
 OCR_VISION_API = env.to_bool("INGESTORS_OCR_VISION_API", False)


### PR DESCRIPTION
Should fix #573

These settings were always there, but when we integrated `convert-document` into `ingest-file` we didn't hook them up.

I've also reduced the defaults to something more sensible ™️ 