### PR TITLE
Introduce a setting to disable sending ProcessingExceptions to Sentry

### DIFF
--- a/ingestors/manager.py
+++ b/ingestors/manager.py
@@ -219,7 +219,8 @@ class Manager(object):
             log.exception(f"[{repr(entity)}] Failed to process: {pexc}")
             INGESTIONS_FAILED.labels(ingestor=ingestor_name).inc()
             entity.set("processingError", stringify(pexc))
-            capture_exception(pexc)
+            if settings.SENTRY_CAPTURE_PROCESSING_EXCEPTIONS:
+                capture_exception(pexc)
         finally:
             self.finalize(entity)
 

--- a/ingestors/settings.py
+++ b/ingestors/settings.py
@@ -50,3 +50,10 @@ fts.DATABASE_URI = env.get(
 
 # Also store cached values in the SQL database
 sls.TAGS_DATABASE_URI = fts.DATABASE_URI
+
+# ProcessingException is thrown whenever something goes wrong wiht
+# parsing a file. Enable this with care, it can easily eat up the
+# Sentry quota of events.
+SENTRY_CAPTURE_PROCESSING_EXCEPTIONS = env.to_bool(
+    "SENTRY_CAPTURE_PROCESSING_EXCEPTIONS", False
+)


### PR DESCRIPTION
A `ProcessingException` is thrown every time `ingest-file` isn't able to parse a file. In the current state, if Sentry support is enabled, each of these will create an event in Sentry. While these are valuable to have they can easily overwhelm the events budget so we are introducing a flag to disable sending these to Sentry, effectively making this one specific call opt-in. One can still rely on logs to figure out what went wrong in these cases.