### PR TITLE
Add barcode detection to OCR 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -146,6 +146,11 @@ RUN python3 -m spacy download el_core_news_sm \
     && python3 -m spacy download da_core_news_sm
 # RUN python3 -m spacy download zh_core_web_sm
 
+RUN apt-get update && apt-get -qq -y install libzbar0 && apt-get -qq -y autoremove \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+
 COPY . /ingestors
 WORKDIR /ingestors
 RUN pip3 install --no-cache-dir --config-settings editable_mode=compat --use-pep517 -e /ingestors

--- a/Dockerfile
+++ b/Dockerfile
@@ -102,6 +102,7 @@ RUN apt-get -qq -y update \
     fonts-droid-fallback fonts-dustin fonts-f500 fonts-fanwood fonts-freefont-ttf \
     fonts-liberation fonts-lmodern fonts-lyx fonts-sil-gentium fonts-texgyre \
     fonts-tlwg-purisa \
+    libzbar0 \
     ###
     && apt-get -qq -y autoremove \
     && apt-get clean \
@@ -145,11 +146,6 @@ RUN python3 -m spacy download el_core_news_sm \
     && python3 -m spacy download nb_core_news_sm \
     && python3 -m spacy download da_core_news_sm
 # RUN python3 -m spacy download zh_core_web_sm
-
-RUN apt-get update && apt-get -qq -y install libzbar0 && apt-get -qq -y autoremove \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
-    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 
 COPY . /ingestors
 WORKDIR /ingestors

--- a/ingestors/support/ocr.py
+++ b/ingestors/support/ocr.py
@@ -4,6 +4,11 @@ import threading
 from hashlib import sha1
 from normality import stringify
 from PIL import Image
+
+from pyzbar import pyzbar
+import numpy as np
+import cv2
+
 from io import BytesIO
 from languagecodes import list_to_alpha3 as alpha3
 
@@ -43,6 +48,87 @@ class OCRSupport(CacheSupport):
             self.tags.set(key, text)
             log.info("OCR: %s chars (from %s bytes)", len(text), len(data))
         return stringify(text)
+
+
+class ZBarDetectorService(object):
+    THRESHOLDS = list(range(32, 230, 32))
+
+    def _enhance_image(self, image, threshold=127):
+        width, height = image.size
+        crop = (0, height - width * 3 / 2, width, height)
+        # Convert to grayscale using Pillow
+        gray_image = image.convert("L")
+
+        # Convert Pillow image to OpenCV format
+        opencv_image = np.array(gray_image)
+
+        # Apply Gaussian blur to reduce noise
+        blurred_image = cv2.GaussianBlur(opencv_image, (3, 3), 0)
+
+        # Apply thresholding using OpenCV
+        _, thresh_image = cv2.threshold(
+            blurred_image, threshold, 255, cv2.THRESH_BINARY
+        )
+
+        # Apply morphological transformations to enhance the QR code
+        kernel = np.ones((3, 3), np.uint8)
+        dilated_image = cv2.dilate(thresh_image, kernel, iterations=1)
+        eroded_image = cv2.erode(dilated_image, kernel, iterations=1)
+
+        # Resize the image to make the QR code larger
+        scale_percent = 200  # Adjust the scale as needed
+        width = int(eroded_image.shape[1] * scale_percent / 100)
+        height = int(eroded_image.shape[0] * scale_percent / 100)
+        dim = (width, height)
+        resized_image = cv2.resize(eroded_image, dim, interpolation=cv2.INTER_LINEAR)
+        resized_image = cv2.GaussianBlur(eroded_image, (5, 5), 0)
+
+        return Image.fromarray(resized_image)
+
+    def _serialize_zbar_result(self, result):
+        return "\n".join(
+            [
+                "",
+                "--- CODE ---",
+                "TYPE: {}".format(result.type),
+                "QUALITY: {}".format(result.quality),
+                "ORIENTATION: {}".format(result.orientation),
+                "POSITION: {}".format(list(result.rect)),
+                "DATA: {}".format(result.data.decode("utf-8")),
+            ]
+        )
+
+    def _results_to_text(self, results):
+        return "---\n".join([self._serialize_zbar_result(result) for result in results])
+
+    def _try_best(self, image):
+        results = pyzbar.decode(image)
+        # Found it at first try
+        if len(results) > 0:
+            log.info("OCR: zbar found (%d) results at first shot", len(results))
+            return results
+
+        log.info("OCR: zbar ehnahcing image")
+        # Try with our enhance logic
+        for threshold in self.THRESHOLDS:
+            log.info("OCR: zbar applying threshold %d", threshold)
+            new_image = self._enhance_image(image, threshold=threshold)
+            results = pyzbar.decode(new_image)
+
+            if len(results) > 0:
+                log.info(
+                    "OCR: zbar found (%d) results with threshold=%d",
+                    len(results),
+                    threshold,
+                )
+                return results
+
+        # no results found then
+        return []
+
+    def extract_barcodes(self, image):
+        log.info("OCR: zbar scanning for codes")
+        return self._results_to_text(self._try_best(image))
 
 
 class LocalOCRService(object):
@@ -90,6 +176,7 @@ class LocalOCRService(object):
             log.error("Cannot open image data using Pillow: %s", exc)
             return ""
 
+        text = ""
         with temp_locale(TESSERACT_LOCALE):
             languages = self.language_list(languages)
             api = self.configure_engine(languages)
@@ -109,12 +196,13 @@ class LocalOCRService(object):
                     confidence,
                     duration,
                 )
-                return text
             except Exception as exc:
                 log.error("OCR error: %s", exc)
-                return ""
             finally:
                 api.Clear()
+
+        text += ZBarDetectorService().extract_barcodes(image)
+        return text
 
 
 class GoogleOCRService(object):

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,9 @@ tesserocr==2.6.2
 spacy==3.6.1
 fingerprints==1.1.1
 fasttext==0.9.2
+pyzbar==0.1.9
+opencv-python==4.10.0.84
+numpy==1.24.4
 
 # Development
 pytest==8.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,8 +13,6 @@ spacy==3.6.1
 fingerprints==1.1.1
 fasttext==0.9.2
 pyzbar==0.1.9
-opencv-python==4.10.0.84
-numpy==1.24.4
 
 # Development
 pytest==8.2.0


### PR DESCRIPTION
`LocalOCRService` can now detect 1D barcodes and QR Codes via [pyzbar][pyzbar].

In our investigations we've realized that QR detection can be impaired if the QR Code contain artifacts/noise within the code. We've included a parametrizable processing pipeline to minimize artifacts and improve the scanner performance.

Before (not detected by zbar):
![image](https://github.com/user-attachments/assets/a4094113-4ca7-4bd5-84f9-49e07da8e25a)

After (detected):
![image](https://github.com/user-attachments/assets/2b232397-cdb9-4cec-b12e-98c225bc424b)

The results of `pyzbar` are appended at the end of the OCR output in the form of:

```
--- QRCODE CODE ---
QUALITY: 1
ORIENTATION: UP
POSITION: [278, 18549, 1352, 1386]
DATA: 190401021.01.1.0001!54,3,0,0,2,0,0,0,3,0,0,1,4,0,0,0,0,1,0,0,0,1,0,0,0,0,0,0,1,0,0,0,0,2,2,68,1,0!0!0
```
_Note: result extracted from the sample images above_

We have some preliminary timings as well as part of this change. In a best-case scenario (pyzbar finds codes at first try) it'll take ~450ms more than current master, and if it needs to go over the processing pipeline every attempt takes ~1.5s.

Open Questions:
- [] Are log messages ok?
- [] Is the logic aligned with your style? I tried my best to match it

[pyzbar]: https://pypi.org/project/pyzbar/