### PR TITLE
Fix tesserocr build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,8 @@ jobs:
           make cached-build
       - name: Install development dependencies
         run: make dev
+        env:
+          PIP_BREAK_SYSTEM_PACKAGES: 1
       - name: Check formatting
         run: make format-check
       - name: Run linter (ruff)

--- a/Dockerfile
+++ b/Dockerfile
@@ -155,7 +155,8 @@ ENV ARCHIVE_TYPE=file \
     ARCHIVE_PATH=/data \
     FTM_STORE_URI=postgresql://aleph:aleph@postgres/aleph \
     REDIS_URL=redis://redis:6379/0 \
-    TESSDATA_PREFIX=/usr/share/tesseract-ocr/4.00/tessdata
+    TESSDATA_PREFIX=/usr/share/tesseract-ocr/4.00/tessdata \
+    LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libgomp.so.1
 
 # USER app
 CMD ingestors process

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ normality==2.5.0
 pantomime==0.6.1
 followthemoney==3.5.9
 followthemoney-store[postgresql]==3.1.0
-servicelayer[google,amazon]==1.23.0rc33
+servicelayer[google,amazon]==1.23.0-rc36
 languagecodes==1.1.1
 countrytagger==0.1.2
 pyicu==2.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ normality==2.5.0
 pantomime==0.6.1
 followthemoney==3.5.9
 followthemoney-store[postgresql]==3.1.0
-servicelayer[google,amazon]==1.23.0-rc36
+servicelayer[google,amazon]==1.23.0
 languagecodes==1.1.1
 countrytagger==0.1.2
 pyicu==2.12


### PR DESCRIPTION
Fixing the runtime error ```libgomp.so.1: cannot allocate memory in static TLS block``` (we build tesserocr manually in the Dockerfile because the wheels don't have support for all file formats we use).