### PR TITLE
fix: parsing of multiline MIME encoded headers

### DIFF
--- a/tests/fixtures/email_multiline_headers.eml
+++ b/tests/fixtures/email_multiline_headers.eml
@@ -1,0 +1,27 @@
+From redacted@example.com  Mon Sep 26 01:29:17 2016
+Return-Path: <redacted@example.com>
+MIME-Version: 1.0
+Content-Type: multipart/mixed;
+ boundary="=_cdba8b1f8013db8af57404a79c9f2707"
+Date: Fri, 29 Apr 2016 11:17:12 +0300
+From: =?UTF-8?Q?=D0=9E=D1=82=D0=B4=D0=B5=D0=BB_=D0=BF=D0=BE_=D1=80=D0=B0?=
+ =?UTF-8?Q?=D0=B1=D0=BE=D1=82=D0=B5_=D1=81_=D0=BF=D1=80=D0=BE=D1=85=D0=BE?=
+ =?UTF-8?Q?=D0=B6=D0=B4=D0=B5=D0=BD=D0=B8=D0=B5=D0=BC_=D0=B7=D0=B0=D0=BA?=
+ =?UTF-8?Q?=D0=BE=D0=BD=D0=BE=D0=BF=D1=80=D0=BE=D0=B5=D0=BA=D1=82=D0=BE?=
+ =?UTF-8?Q?=D0=B2?= <redacted@example.com>
+To: =?UTF-8?Q?=D0=91=D0=BE=D1=80=D0=B8=D1=81=D0=BE=D0=B2?=
+ <redacted@example.org>
+Subject: =?UTF-8?Q?=D0=94=D0=BE=D0=BF=D0=BE=D0=BB=D0=BD=D0=B8=D1=82=D0=B5?=
+ =?UTF-8?Q?=D0=BB=D1=8C=D0=BD=D0=BE=D0=B5_=D0=B7=D0=B0=D0=BA=D0=BB=D1=8E?=
+ =?UTF-8?Q?=D1=87=D0=B5=D0=BD=D0=B8=D0=B5_=D0=9F=D1=80=D0=BE=D1=84=D0=B8?=
+ =?UTF-8?Q?=D0=BB=D1=8C=D0=BD=D0=BE=D0=B3=D0=BE_=D0=9A=D0=BE=D0=BC=D0=B8?=
+ =?UTF-8?Q?=D1=82=D0=B5=D1=82=D0=B0_=D0=BD=D0=B0_=D0=BF=D1=80=D0=BE=D0=B5?=
+ =?UTF-8?Q?=D0=BA=D1=82_=D0=B7=D0=B0=D0=BA=D0=BE=D0=BD=D0=B0_=E2=84=96145-?=
+ =?UTF-8?Q?=D0=94?=
+Message-ID: <ccdff393603faa4df447dc8903c14a57@example.com>
+X-Sender: redacted@example.com
+User-Agent: Roundcube Webmail/1.1.1
+
+--=_cdba8b1f8013db8af57404a79c9f2707
+--=_cdba8b1f8013db8af57404a79c9f2707--
+

--- a/tests/test_msg.py
+++ b/tests/test_msg.py
@@ -167,3 +167,20 @@ class RFC822Test(TestCase):
                 "This is the body of a plaintext message.",
             ],
         )
+
+    def test_headers(self):
+        fixture_path, entity = self.fixture("email_multiline_headers.eml")
+        self.manager.ingest(fixture_path, entity)
+        self.assertSuccess(entity)
+        self.assertEqual(
+            entity.get("from"),
+            [
+                "Отдел по работе с прохождением законопроектов <redacted@example.com>",
+            ],
+        )
+        self.assertEqual(
+            entity.get("subject"),
+            [
+                "Дополнительное заключение Профильного Комитета на проект закона №145-Д",
+            ]
+        )


### PR DESCRIPTION
The email parser incorrectly parses multiline MIME-encoded headers. For example, given this header:

```
From: =?UTF-8?Q?=D0=9E=D1=82=D0=B4=D0=B5=D0=BB_=D0=BF=D0=BE_=D1=80=D0=B0?=
 =?UTF-8?Q?=D0=B1=D0=BE=D1=82=D0=B5_=D1=81_=D0=BF=D1=80=D0=BE=D1=85=D0=BE?=
 =?UTF-8?Q?=D0=B6=D0=B4=D0=B5=D0=BD=D0=B8=D0=B5=D0=BC_=D0=B7=D0=B0=D0=BA?=
 =?UTF-8?Q?=D0=BE=D0=BD=D0=BE=D0=BF=D1=80=D0=BE=D0=B5=D0=BA=D1=82=D0=BE?=
 =?UTF-8?Q?=D0=B2?= <redacted@example.com>
```

It is parsed as

```
Отдел по ра боте с прохо ждением зак онопроекто в <redacted@example.com>
```

instead of

```
Отдел по работе с прохождением законопроектов <redacted@example.com>
```

That is, the lines of the headers are joined with a space, and then the result is decoded. The expected behavior is concatenating the lines, discarding the continuation whitespace characters. This is what, for example, Thunderbird (and other mail clients) does:

![Screenshot_20250506_123048](https://github.com/user-attachments/assets/6165aee7-43ff-4e3f-8c30-d61de60b5bd1)

This behavior can be verified with, for example, https://dogmamix.com/MimeHeadersDecoder/

As a side effect, the current behavior results in creation of many unnecessary aliases of the same name, like this:

![Screenshot_20250506_123325](https://github.com/user-attachments/assets/43198e91-9edf-4420-b08c-fd7d820f8fdb)

Unfortunately, the issue is in Python's internals. The `compat32` policy, however, parses the headers correctly (`make_header(decode_header(value))` produces the expected result).

This PR attempts to fix the described issue by using a custom policy derived from `email.policy.default` that implements `header_fetch_parse` the way `email.policy.compat32` does (and maintaining compatibility with `email.policy.default`).

However, I am not a Python developer; there could be a cleaner (or better) way to do this. But it works :-)
